### PR TITLE
chore(config): increase default axios timeout to 5s

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -4,6 +4,6 @@ module.exports = {
         version: "1.1"
     },
     axios: {
-        timeout: 2000
+        timeout: 5000
     }
 };


### PR DESCRIPTION
### Purpose
The old default timeout value was too small.

<!-- uncomment this section if it's relevant !
### Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
-->

### Checklist
<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] Configuration changes
- [ ] Added tests

<!-- To close resolved issues, add "Closes #ISSUE_NUMBER" -->

<!-- If this PR depends on a previous one, add "Depends on #PR_NUMBER" + select label `status:on-hold` -->
