### PR TITLE
Refactor/use instance instead of static

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Request = require("./lib/utils/Request");
+const Config = require("./lib/utils/Config");
 const Campaign = require("./lib/Campaign");
 
 /**
@@ -8,9 +8,10 @@ const Campaign = require("./lib/Campaign");
  * }}
  */
 module.exports = function BatchClient (opts) {
-    const req = Request.init(opts);
+    const cfg = new Config();
+    cfg.setUserOptions(opts);
 
     return {
-        campaign: Campaign(req)
+        campaign: new Campaign(cfg)
     };
 };

--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -1,17 +1,24 @@
 const Ajv = require("ajv");
+const Request = require("./utils/Request");
 const parameters = require("../config/parameters/campaign");
 
 const ajv = new Ajv({allErrors: true});
 const validate = ajv.compile(parameters);
 
-let request;
-
 class Campaign {
+    /**
+     *
+     * @param {Config} cfg
+     */
+    constructor (cfg) {
+        this.request = new Request(cfg);
+    }
+
     /**
      * @param {Object} payload
      * @returns {Promise.<String, Error>} get the campaign token if fulfilled
      */
-    static create (payload) {
+    create (payload) {
         // don't send the payload if it's malformed
         const isValid = validate(payload);
 
@@ -19,7 +26,7 @@ class Campaign {
             return Promise.reject(new Error(`payload invalid. Reason: "${ajv.errorsText(validate.errors)}"`));
         }
 
-        return request.post("/campaigns/create", payload)
+        return this.request.post("/campaigns/create", payload)
         .then(function (response) {
             const tokenKey = "campaign_token";
 
@@ -36,7 +43,7 @@ class Campaign {
      * @param {Object} payload
      * @returns {Promise.<undefined, Error>}
      */
-    static update (token, payload) {
+    update (token, payload) {
         // don't send the payload if it's malformed
         const isValid = validate(payload);
 
@@ -44,15 +51,11 @@ class Campaign {
             return Promise.reject(new Error(`payload invalid. Reason: "${ajv.errorsText(validate.errors)}"`));
         }
 
-        return request.post(`/campaigns/update/${token}`, payload);
+        return this.request.post(`/campaigns/update/${token}`, payload);
     }
 }
 
 /**
- * @param {Axios} req
  * @returns {Campaign}
  */
-module.exports = function (req) {
-    request = req;
-    return Campaign;
-};
+module.exports = Campaign;

--- a/lib/utils/Config.js
+++ b/lib/utils/Config.js
@@ -4,30 +4,32 @@ const defaultOptions = require("../../config/default");
 const userOptions = require("../../config/userOptions");
 const log = require("./Logger");
 
-class ConfigStore {
-    constructor () {
-        this.ajv = new Ajv({
-            allErrors: true,
-            useDefaults: true,
-            coerceTypes: true
-        });
-        this.validate = this.ajv.compile(userOptions);
+// compile the schema validator once
+const ajv = new Ajv({
+    allErrors: true,
+    useDefaults: true,
+    coerceTypes: true
+});
+const validate = ajv.compile(userOptions);
 
+class Config {
+    constructor () {
         // retrieve default values
         this.options = defaultOptions;
     }
 
     /**
      * Merge default options with the given options
+     * Note that this will overwrite current config entries !
      *
-     * @param {Object} [userOptions={}]
+     * @param {Object} [userOpts={}]
      * @returns {Boolean} true if updated successfully, else false (see logs)
      */
-    update (userOptions = {}) {
-        const isValid = this.validate(userOptions);
+    setUserOptions (userOpts = {}) {
+        const isValid = validate(userOpts);
 
         if (!isValid) {
-            log.error(this.ajv.errorText(this.validate.errors));
+            log.error(ajv.errorText(validate.errors));
 
             return false;
         }
@@ -35,25 +37,10 @@ class ConfigStore {
         // deep merge values in case user would want to update sub-properties
         // e.g. changing only "bar" value to `true` in `{ foo: { bar: false, baz: false } }`
         // XXX atm, we only consider API "custom" configuration
-        _.merge(this.options, {api: userOptions});
+        _.merge(this.options, {api: userOpts});
 
         return true;
     }
-}
-
-// instantiate only one store
-let globalConfig = new ConfigStore();
-
-module.exports = {
-    /**
-     * Note that this will overwrite current config entries !
-     *
-     * @param {Object} opts
-     * @returns {Boolean} true in case of succeeded update
-     */
-    setUserOptions (opts) {
-        return globalConfig.update(opts);
-    },
 
     /**
      *
@@ -61,8 +48,8 @@ module.exports = {
      * @returns {Boolean}
      */
     has (key) {
-        return _.has(globalConfig.options, key);
-    },
+        return _.has(this.options, key);
+    }
 
     /**
      *
@@ -70,6 +57,8 @@ module.exports = {
      * @returns {String} empty if the key doesn't exist
      */
     get (key) {
-        return _.get(globalConfig.options, key, "");
+        return _.get(this.options, key, "");
     }
-};
+}
+
+module.exports = Config;

--- a/lib/utils/Request.js
+++ b/lib/utils/Request.js
@@ -1,22 +1,13 @@
 const axios = require("axios");
-const Config = require("./Config");
 const log = require("./Logger");
-
-// store only one instance of Axios
-let axiosInstance;
 
 class Request {
     /**
-     * @param {Object} keys
+     * @param {Config} cfg
      * @returns {Axios} instance
      * @throws {Error} if the Batch API key is missing
      */
-    static init (keys) {
-        if (axiosInstance) {
-            return axiosInstance;
-        }
-
-        Config.setUserOptions(keys);
+    constructor (cfg) {
 
         // use live key in production
         const isProd = (process.env.NODE_ENV === "production");
@@ -28,16 +19,16 @@ class Request {
             keyFromEnv = "api.devKey";
         }
 
-        const key = Config.get(keyFromEnv);
+        const key = cfg.get(keyFromEnv);
 
         // check that the key is set for the right env.
         if (!key) {
             throw new Error(`missing key "${keyFromEnv}" for the env. "${process.env.NODE_ENV}"`);
         }
 
-        const url = `${Config.get("api.baseURL")}/${Config.get("api.version")}/${key}`;
+        const url = `${cfg.get("api.baseURL")}/${cfg.get("api.version")}/${key}`;
 
-        axiosInstance = axios.create({
+        this.axiosInstance = axios.create({
             baseURL: url,
             validateStatus: function (status) {
                 return status >= 100 && status < 400;
@@ -45,9 +36,9 @@ class Request {
         });
 
         // Alter defaults after instance has been created
-        axiosInstance.defaults.headers.common["X-Authorization"] = Config.get("api.restKey");
-        axiosInstance.defaults.headers.post["Content-Type"] = "application/json";
-        axiosInstance.defaults.timeout = Config.get("axios.timeout");
+        this.axiosInstance.defaults.headers.common["X-Authorization"] = cfg.get("api.restKey");
+        this.axiosInstance.defaults.headers.post["Content-Type"] = "application/json";
+        this.axiosInstance.defaults.timeout = cfg.get("axios.timeout");
 
         const successResponse = function (response) {
             const request = response.request;
@@ -86,9 +77,9 @@ class Request {
             return Promise.reject(error);
         };
 
-        axiosInstance.interceptors.response.use(successResponse, failResponse);
+        this.axiosInstance.interceptors.response.use(successResponse, failResponse);
 
-        return axiosInstance;
+        return this.axiosInstance;
     }
 }
 

--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -1,7 +1,6 @@
 const expect = require("chai").expect;
 const nock = require("nock");
 const Config = require("../lib/utils/Config");
-const Request = require("../lib/utils/Request");
 const Campaign = require("../lib/Campaign");
 const fixture = require("./fixtures/campaign");
 const options = require("./fixtures/options");
@@ -12,10 +11,12 @@ describe("Campaign", function () {
     let createdCampaignToken;
 
     before(function () {
-        const request = Request.init(options);
-        campaign = Campaign(request);
+        const cfg = new Config();
+        cfg.setUserOptions(options);
 
-        batchURL = `${Config.get("api.baseURL")}/${Config.get("api.version")}/${Config.get("api.devKey")}`;
+        campaign = new Campaign(cfg);
+
+        batchURL = `${cfg.get("api.baseURL")}/${cfg.get("api.version")}/${cfg.get("api.devKey")}`;
     });
 
     it("should create a campaign", function (done) {


### PR DESCRIPTION
### Purpose
We were having issues with the fact that we're calling `batch` multiple times. But using the same `axios` instance (with the baseURL unchanged) was provoking an error : each time `batch` was called, it sends the request to the first given "API Key" !

<!-- uncomment this section if it's relevant !
### Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
-->

### Checklist
<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] Configuration changes
- [x] Added tests

<!-- To close resolved issues, add "Closes #ISSUE_NUMBER" -->

<!-- If this PR depends on a previous one, add "Depends on #PR_NUMBER" + select label `status:on-hold` -->
