### PR TITLE
fix(Request): relax rules when setting the API keys

### DIFF
--- a/lib/utils/Request.js
+++ b/lib/utils/Request.js
@@ -8,22 +8,16 @@ class Request {
      * @throws {Error} if the Batch API key is missing
      */
     constructor (cfg) {
+        const liveKey = cfg.get("api.liveKey");
+        const devKey = cfg.get("api.devKey");
+        const key = liveKey || devKey;
 
-        // use live key in production
-        const isProd = (process.env.NODE_ENV === "production");
-        let keyFromEnv;
-
-        if (isProd) {
-            keyFromEnv = "api.liveKey";
-        } else {
-            keyFromEnv = "api.devKey";
-        }
-
-        const key = cfg.get(keyFromEnv);
-
-        // check that the key is set for the right env.
+        // check that the key is set
         if (!key) {
-            throw new Error(`missing key "${keyFromEnv}" for the env. "${process.env.NODE_ENV}"`);
+            throw new Error('no API keys found ! You must set a valid "live" or "dev" key');
+        } else {
+            const usedKey = (liveKey === key) ? "liveKey" : "devKey";
+            log.info(`using the "${usedKey}" in requests ...`);
         }
 
         const url = `${cfg.get("api.baseURL")}/${cfg.get("api.version")}/${key}`;


### PR DESCRIPTION
### Purpose
We were fetching the liveKey only when a global env. var. was set to "production"
which were creating too much constraint.

<!-- uncomment this section if it's relevant !
### Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
-->

### Checklist
<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] Configuration changes
- [ ] Added tests

<!-- To close resolved issues, add "Closes #ISSUE_NUMBER" -->

<!-- If this PR depends on a previous one, add "Depends on #PR_NUMBER" + select label `status:on-hold` -->
