### PR TITLE
Feat/add missing routes campaigns

### DIFF
--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -140,6 +140,18 @@ class Campaign {
     }
 
     /**
+     * Check if the token exists for the API key
+     *
+     * @param {String} token
+     * @returns {Promise.<Boolean, Error>}
+     */
+    has (token) {
+        return this.get(token)
+        .then(() => true)
+        .catch(() => false);
+    }
+
+    /**
      * campaign stats are composed of the following properties
      * @typedef {Object} Stats
      * @property {Date} date

--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -92,6 +92,24 @@ class Campaign {
      * @see {@link https://batch.com/doc/api/campaigns/parameters.html}
      */
 
+    /**
+     * Warning: You'll have to use your "live" key in order to fetch the details!
+     *
+     * You can refer to the official docs to get the details:
+     * @see {@link https://batch.com/doc/api/campaigns/get-campaign.html}
+     *
+     * @param {String} token
+     * @returns {Promise.<CampaignInfos, Error>}
+     */
+    get (token) {
+        if (!token || typeof token !== "string") {
+            return Promise.reject(new Error("the token must be a non-empty string"));
+        }
+
+        return this.request.get(`/campaigns/${token}`)
+        .then(response => response.data);
+    }
+
 
     /**
      * campaign stats are composed of the following properties

--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -1,3 +1,4 @@
+const querystring = require("querystring");
 const Ajv = require("ajv");
 const Request = require("./utils/Request");
 const parameters = require("../config/parameters/campaign");
@@ -110,6 +111,33 @@ class Campaign {
         .then(response => response.data);
     }
 
+    /**
+     * Warning: You'll have to use your "live" key in order to fetch the listing!
+     *
+     * You can refer to the official docs to get the details:
+     * @see {@link https://batch.com/doc/api/campaigns/get-campaign.html}
+     *
+     * @param {Number} [from=0]
+     * @param {Number} [limit=10] the maximum allowed value is 100
+     * @param {Boolean} [live]
+     * @param {Boolean} [fromAPI]
+     * @returns {Promise.<Array.<CampaignInfos>, Error>}
+     */
+    list (from = 0, limit = 10, live, fromAPI) {
+        const queryParams = {
+            from,
+            limit
+        };
+
+        // only add the following parameters if there're set
+        if (typeof live === "boolean") queryParams.live = live;
+        if (typeof fromAPI === "boolean") queryParams.from_api = fromAPI;
+
+        const queryString = querystring.stringify(queryParams);
+
+        return this.request.get(`/campaigns/list?${queryString}`)
+        .then(response => response.data);
+    }
 
     /**
      * campaign stats are composed of the following properties

--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -152,6 +152,26 @@ class Campaign {
     }
 
     /**
+     * Force the activation of one campaign
+     *
+     * @param {String} token
+     * @returns {Promise.<undefined, Error>}
+     */
+    enable (token) {
+        return this.update(token, {live: true});
+    }
+
+    /**
+     * Disable one campaign
+     *
+     * @param {String} token
+     * @returns {Promise.<undefined, Error>}
+     */
+    disable (token) {
+        return this.update(token, {live: false});
+    }
+
+    /**
      * campaign stats are composed of the following properties
      * @typedef {Object} Stats
      * @property {Date} date

--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -15,6 +15,9 @@ class Campaign {
     }
 
     /**
+     * Create a new campaign using the given payload
+     * @see {@link https://batch.com/doc/api/campaigns/parameters.html} to get the possible parameters
+     *
      * @param {Object} payload
      * @returns {Promise.<String, Error>} get the campaign token if fulfilled
      */
@@ -39,6 +42,9 @@ class Campaign {
     }
 
     /**
+     * the possible parameters to create a payload is on the following link:
+     * @see {@link https://batch.com/doc/api/campaigns/parameters.html}
+     *
      * @param {String} token
      * @param {Object} payload
      * @returns {Promise.<undefined, Error>}

--- a/lib/Campaign.js
+++ b/lib/Campaign.js
@@ -71,19 +71,40 @@ class Campaign {
     }
 
     /**
+     * campaign infos are composed of *at least* the following properties
+     *
+     * @typedef {Object} CampaignInfos
+     * @property {String} campaign_token
+     * @property {Boolean} from_api
+     * @property {Boolean} dev_only
+     * @property {Date} created_date
+     * @property {String} name
+     * @property {String} live
+     * @property {Date} push_time
+     *
+     * to get the complete list:
+     * @see {@link https://batch.com/doc/api/campaigns/parameters.html}
+     */
+
+
+    /**
+     * campaign stats are composed of the following properties
+     * @typedef {Object} Stats
+     * @property {Date} date
+     * @property {Number} sent
+     * @property {Number} direct_open
+     * @property {Number} influenced_open
+     * @property {Number} open_rate
+     * @property {Number} reengaged
+     * @property {Number} errors
+     */
+
+    /**
      * @param {String} token
-     * @returns {Promise.<Object, Error>} get the campaign stats if fulfilled.
-     * The result contains the following properties:
-     * - date: Date
-     * - sent: Number
-     * - direct_open: Number
-     * - influenced_open: Number
-     * - open_rate: Number
-     * - reengaged: Number
-     * - errors: Number
+     * @returns {Promise.<Stats, Error>} get the campaign stats if fulfilled.
      *
      * You can refer to the official docs to get the details:
-     * @link https://batch.com/doc/dashboard/push/analytics.html
+     * @see {@link https://batch.com/doc/dashboard/push/analytics.html}
      */
     stats (token) {
         if (!token || typeof token !== "string") {

--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -119,6 +119,56 @@ describe("Campaign", function () {
         .catch(err => done(err));
     });
 
+    it("should get infos from an existing campaign", function (done) {
+        const reply = fixture.get.reply;
+        const status = fixture.get.statusCode;
+
+        nock(batchURL)
+        .get(`/campaigns/${createdCampaignToken}`)
+        .reply(status, reply);
+
+        campaign.get(createdCampaignToken)
+        .then(function (result) {
+            expect(result).to.deep.equal(reply);
+            done();
+        })
+        .catch(err => done(err));
+    });
+
+    it("should list the existing campaigns", function (done) {
+        const reply = fixture.list.reply;
+        const status = fixture.list.statusCode;
+
+        nock(batchURL)
+        .get("/campaigns/list")
+        .query({
+            from: 0,
+            limit: 10
+        })
+        .reply(status, reply);
+
+        campaign.list()
+        .then(function (result) {
+            expect(result).to.deep.equal(reply);
+            done();
+        })
+        .catch(err => done(err));
+    });
+
+    it("should check that the existing campaign exists", function (done) {
+        const status = fixture.get.statusCode;
+
+        nock(batchURL)
+        .get(`/campaigns/${createdCampaignToken}`)
+        .reply(status);
+
+        campaign.has(createdCampaignToken)
+        .then(function (isCreated) {
+            expect(isCreated).to.be.true;
+            done();
+        })
+        .catch(err => done(err));
+    });
     it("should update an existing campaign", function (done) {
         const payload = fixture.createMinimal.payload;
         const status = fixture.createMinimal.statusCode;

--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -169,17 +169,29 @@ describe("Campaign", function () {
         })
         .catch(err => done(err));
     });
+
     it("should update an existing campaign", function (done) {
         const payload = fixture.createMinimal.payload;
         const status = fixture.createMinimal.statusCode;
+        const reply = fixture.get.reply;
 
         nock(batchURL)
         .post(`/campaigns/update/${createdCampaignToken}`, payload)
         .reply(status);
 
+        nock(batchURL)
+        .get(`/campaigns/${createdCampaignToken}`)
+        .reply(status, reply);
+
         campaign.update(createdCampaignToken, payload)
-        .then(() => done())
-        .catch((err) => done(err));
+        .then(() => campaign.get(createdCampaignToken))
+        .then(function (result) {
+            expect(result).to.deep.equal(reply);
+            done();
+        })
+        .catch(err => done(err));
+    });
+
     });
 
     it("should fetch stats from an existing campaign", function (done) {

--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -234,6 +234,8 @@ describe("Campaign", function () {
         .catch(err => done(err));
     });
 
+    // XXX stats cannot be fetched right after the campaign creation
+    // so this will only work when mocking HTTP requests
     it("should fetch stats from an existing campaign", function (done) {
         const replyStats = fixture.createMinimal.replyStats;
         const expectedStats = fixture.createMinimal.stats;
@@ -248,6 +250,6 @@ describe("Campaign", function () {
             expect(detail).to.be.deep.equal(expectedStats);
             done();
         })
-        .catch((err) => done(err));
+        .catch(err => done(err));
     });
 });

--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -192,6 +192,46 @@ describe("Campaign", function () {
         .catch(err => done(err));
     });
 
+    it("should force-enable an existing campaign", function (done) {
+        const reply = fixture.get.reply;
+        const status = fixture.createMinimal.statusCode;
+
+        nock(batchURL)
+        .post(`/campaigns/update/${createdCampaignToken}`, {live: true})
+        .reply(status);
+
+        nock(batchURL)
+        .get(`/campaigns/${createdCampaignToken}`)
+        .reply(status, reply);
+
+        campaign.enable(createdCampaignToken)
+        .then(() => campaign.get(createdCampaignToken))
+        .then(function (result) {
+            expect(result).to.deep.equal(reply);
+            done();
+        })
+        .catch(err => done(err));
+    });
+
+    it("should force-disable an existing campaign", function (done) {
+        const reply = fixture.get.reply;
+        const status = fixture.createMinimal.statusCode;
+
+        nock(batchURL)
+        .post(`/campaigns/update/${createdCampaignToken}`, {live: false})
+        .reply(status);
+
+        nock(batchURL)
+        .get(`/campaigns/${createdCampaignToken}`)
+        .reply(status, reply);
+
+        campaign.disable(createdCampaignToken)
+        .then(() => campaign.get(createdCampaignToken))
+        .then(function (result) {
+            expect(result).to.deep.equal(reply);
+            done();
+        })
+        .catch(err => done(err));
     });
 
     it("should fetch stats from an existing campaign", function (done) {

--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -5,18 +5,32 @@ const Campaign = require("../lib/Campaign");
 const fixture = require("./fixtures/campaign");
 const options = require("./fixtures/options");
 
+/**
+ * @returns {Campaign}
+ */
+function createCampaignHandler () {
+    const cfg = new Config();
+    cfg.setUserOptions(options);
+    return new Campaign(cfg);
+}
+
+/**
+ * @returns {String}
+ */
+function getURL () {
+    const cfg = new Config();
+    cfg.setUserOptions(options);
+    return `${cfg.get("api.baseURL")}/${cfg.get("api.version")}/${cfg.get("api.devKey")}`;
+}
+
 describe("Campaign", function () {
     let campaign;
     let batchURL = "";
     let createdCampaignToken;
 
     before(function () {
-        const cfg = new Config();
-        cfg.setUserOptions(options);
-
-        campaign = new Campaign(cfg);
-
-        batchURL = `${cfg.get("api.baseURL")}/${cfg.get("api.version")}/${cfg.get("api.devKey")}`;
+        campaign = createCampaignHandler();
+        batchURL = getURL();
     });
 
     it("should create a campaign", function (done) {

--- a/test/fixtures/campaign.js
+++ b/test/fixtures/campaign.js
@@ -18,7 +18,7 @@ exports.createMinimal = {
         "campaign_token": "3396955c1a7fe0005d76973fca00b44a",
         "detail": [
             {
-                "date": "2015-11-20",
+                "date": "2017-03-02T09:43:17",
                 "sent": 754,
                 "direct_open": 102,
                 "influenced_open": 98,
@@ -28,7 +28,7 @@ exports.createMinimal = {
         ]
     },
     stats: {
-        date: new Date("2015-11-20"),
+        date: new Date("2017-03-02T09:43:17"),
         sent: 754,
         direct_open: 102,
         influenced_open: 98,

--- a/test/fixtures/campaign.js
+++ b/test/fixtures/campaign.js
@@ -38,3 +38,50 @@ exports.createMinimal = {
     },
     statusCode: 201
 };
+
+exports.get = {
+    token: {
+        "campaign_token": "3396955c1a7fe0005d76973fca00b44a"
+    },
+    reply: {
+        "campaign_token": "3396955c1a7fe0005d76973fca00b44a",
+        "from_api": true,
+        "dev_only": true,
+        "created_date": "2017-03-02T09:43:17",
+        "name": "minimal notification",
+        "live": false,
+        "push_time": "2017-03-02T09:43:17",
+        "gcm_collapse_key": "default",
+        "targeting": {
+            "segments": [
+                "ONE_TIME",
+                "DORMANT",
+                "ENGAGED",
+                "IMPORTED",
+                "NEW"
+            ]
+        },
+        "messages": [
+            {
+                "title": "Salut le monde !",
+                "body": "Comment ça va ?"
+            }
+        ]
+    },
+    statusCode: 200
+};
+
+exports.list = {
+    reply: [
+        {
+            "campaign_token": "3396955c1a7fe0005d76973fca00b44a",
+            "from_api": true,
+            "dev_only": true,
+            "created_date": "2017-03-02T09:43:17",
+            "name": "minimal notification",
+            "live": false,
+            "push_time": "2017-03-02T09:43:17"
+        }
+    ],
+    statusCode: 200
+};


### PR DESCRIPTION
### Purpose
Add the following missing routes for **Campaigns** in the Batch client:

- `get(token)` get infos for a specific notification campaign
- `list()` list all notification campaigns (paginated)
- `enable(token)` force enable a notification campaign
- `disable(token)` force disable a notification campaign

### Note
This PR was almost fully made and developed by @eilgin. So all the good work goes to him. All I did was review, split and commit while he was on 🌴.

<!-- uncomment this section if it's relevant !
###
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
-->

### Checklist
<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] Configuration changes
- [x] Added tests

<!-- To close resolved issues, add "Closes #ISSUE_NUMBER" -->

<!-- If this PR depends on a previous one, add "Depends on #PR_NUMBER" + select label `status:on-hold` -->
